### PR TITLE
feat(delegate): add devin-delegate skill and routing rules

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,7 @@ node_modules/
 typechain/
 flats/
 data/
+.claude/
 
 # files
 coverage.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Agent Instructions
+
+<!-- devin-delegate:begin -->
+## Devin Delegate Routing — MANDATORY
+
+All Devin calls MUST route through the skill wrapper. Direct `devin --print` and `devin --task` calls are **prohibited** — they bypass envelope checks, fallback routing, clarification handling, and telemetry.
+
+- **One-liner:** `devin-delegate --task "..."`
+- **Interactive:** `devin-delegate --interactive`
+- **Long path (fallback):** `./skills/devin-delegate/scripts/delegate.py --task "..."`
+
+**Why this matters:**
+- Structured envelopes prevent vague handoffs
+- Codex then Claude guidance resolves many clarification loops before human escalation
+- Provider fallback keeps execution moving when Devin fails
+- Telemetry enables continuous improvement
+
+**Bypassing the wrapper will be detected and reported.**
+
+- Always produce an envelope first with `./skills/devin-delegate/scripts/plan_prompt.py --task "..."`.
+- Keep delegation scoped and include acceptance criteria.
+- If Devin asks for clarification, use Codex guidance first and Claude second before asking a human.
+- Inspect telemetry regularly (`./skills/devin-delegate/scripts/devin_delegate_telemetry.py summary --days 14`).
+<!-- devin-delegate:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Agent Instructions
 
 <!-- devin-delegate:begin -->
+
 ## Devin Delegate Routing — MANDATORY
 
 All Devin calls MUST route through the skill wrapper. Direct `devin --print` and `devin --task` calls are **prohibited** — they bypass envelope checks, fallback routing, clarification handling, and telemetry.
@@ -10,6 +11,7 @@ All Devin calls MUST route through the skill wrapper. Direct `devin --print` and
 - **Long path (fallback):** `./skills/devin-delegate/scripts/delegate.py --task "..."`
 
 **Why this matters:**
+
 - Structured envelopes prevent vague handoffs
 - Codex then Claude guidance resolves many clarification loops before human escalation
 - Provider fallback keeps execution moving when Devin fails
@@ -21,4 +23,5 @@ All Devin calls MUST route through the skill wrapper. Direct `devin --print` and
 - Keep delegation scoped and include acceptance criteria.
 - If Devin asks for clarification, use Codex guidance first and Claude second before asking a human.
 - Inspect telemetry regularly (`./skills/devin-delegate/scripts/devin_delegate_telemetry.py summary --days 14`).
+
 <!-- devin-delegate:end -->

--- a/skills/devin-delegate
+++ b/skills/devin-delegate
@@ -1,0 +1,1 @@
+/home/agents/workspace/devin-delegate


### PR DESCRIPTION
## Summary
- Install devin-delegate skill symlink in skills/ directory
- Add mandatory Devin delegate routing block to AGENTS.md
- Ensures all Devin calls route through the wrapper with proper envelope checks, fallback routing, and telemetry

#### Test plan
- [x] Verified devin-delegate symlink points to correct location
- [x] Confirmed routing block follows the standard format
- [x] Checked that skill is accessible via ./skills/devin-delegate/

**Agent:** Devin
**Co-authored-by:** Chimera <chimera_defi@protonmail.com>

Generated with [Devin](https://cli.devin.ai/docs)