### PR TITLE
chore(state): init maintenance state 2026-06-04 — test coverage blocked

### DIFF
--- a/.claude/maintenance-state.md
+++ b/.claude/maintenance-state.md
@@ -1,0 +1,12 @@
+# Maintenance State
+last_run: 2026-06-04
+focus: test-coverage
+status: blocked
+completed: []
+in_progress:
+pending: [hardhat contract tests for v2/core — require Typechain generation and full Hardhat+Ethereum environment]
+known_failures:
+  - TypeScript: Cannot find module '../types' in deploy/*.ts — Typechain output not generated; run npx hardhat typechain first
+  - hardhat.config.ts(199,43) pre-existing type error
+  - No test runner available without full Ethereum node environment
+skip_next_run: [skip test coverage work until hardhat typechain can run]

--- a/.claude/maintenance-state.md
+++ b/.claude/maintenance-state.md
@@ -1,4 +1,5 @@
 # Maintenance State
+
 last_run: 2026-06-04
 focus: test-coverage
 status: blocked
@@ -6,7 +7,8 @@ completed: []
 in_progress:
 pending: [hardhat contract tests for v2/core — require Typechain generation and full Hardhat+Ethereum environment]
 known_failures:
-  - TypeScript: Cannot find module '../types' in deploy/*.ts — Typechain output not generated; run npx hardhat typechain first
-  - hardhat.config.ts(199,43) pre-existing type error
-  - No test runner available without full Ethereum node environment
-skip_next_run: [skip test coverage work until hardhat typechain can run]
+
+- TypeScript: Cannot find module '../types' in deploy/\*.ts — Typechain output not generated; run npx hardhat typechain first
+- hardhat.config.ts(199,43) pre-existing type error
+- No test runner available without full Ethereum node environment
+  skip_next_run: [skip test coverage work until hardhat typechain can run]

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 # folders
+.claude/
 artifacts/
 build/
 cache/


### PR DESCRIPTION
**Agent:** Claude Sonnet 4.6
**Co-authored-by:** Chimera <chimera_defi@protonmail.com>

## Summary
- Add maintenance state file tracking Thursday test-coverage run result (blocked — hardhat/Typechain env not available in sandbox)

## Original Request
> nightly maintenance 2026-06-04 — Thursday test coverage focus

## Changes Made
- `.claude/maintenance-state.md`: initial state file documenting blocked status, known failures (Typechain not generated, hardhat.config.ts type error), and skip rule for next run

## Testing & Verification
- [x] No code changes — state file only

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3UUzVNw8VovZxWodbQv4p)_