### PR TITLE
chore(maintenance): 2026-06-16 - TS cleanup pass [Agent: Claude Sonnet 4.6]

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -217,6 +217,7 @@ function getSortedFiles(dependenciesGraph: Record<string, unknown[]>) {
   return sortedNames.map((n: string) => filesMap[n]);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getFileWithoutImports(resolvedFile: any) {
   const IMPORT_SOLIDITY_REGEX = /^\s*import(\s+)[\s\S]*?;\s*$/gm;
 
@@ -228,6 +229,7 @@ subtask("flat:get-flattened-sources", "Returns all contracts and their dependenc
   .addOptionalParam("output", undefined, undefined, types.string)
   .setAction(async ({files, output}, {run}) => {
     const dependencyGraph = await run("flat:get-dependency-graph", {files});
+    // eslint-disable-next-line no-console
     console.log(dependencyGraph);
 
     let flattened = "";
@@ -259,6 +261,7 @@ subtask("flat:get-flattened-sources", "Returns all contracts and their dependenc
 
     flattened = flattened.trim();
     if (output) {
+      // eslint-disable-next-line no-console
       console.log("Writing to", output);
       fs.writeFileSync(output, flattened);
       return "";
@@ -328,6 +331,7 @@ task("accounts", "Prints the list of accounts", async (taskArgs, hre) => {
   const accounts = await hre.ethers.getSigners();
 
   for (const account of accounts) {
+    // eslint-disable-next-line no-console
     console.log(account.address);
   }
 });

--- a/test/v2/core/withdrawalQueueE2E.spec.ts
+++ b/test/v2/core/withdrawalQueueE2E.spec.ts
@@ -30,7 +30,8 @@ describe("WithdrawalQueue E2E - Mainnet Fork", () => {
   let deployer: SignerWithAddress;
   let alice: SignerWithAddress;
   let bob: SignerWithAddress;
-  let vEth2: any; // vETH2 contract on mainnet
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let vEth2: any; // vETH2 contract on mainnet — no Typechain types available
 
   const EPOCH_LENGTH = 100; // 100 blocks for realistic testing
 


### PR DESCRIPTION
**Agent:** Claude Sonnet 4.6
**Co-authored-by:** Chimera <chimera_defi@protonmail.com>

## Summary
- Resolve all 5 ESLint warnings from `npm run lint:ts` in `hardhat.config.ts` and `withdrawalQueueE2E.spec.ts`
- `lint:ts` now exits with zero warnings

## Original Request
> Nightly maintenance — DOW=2 TS/Go cleanup pass

## Changes Made
- `hardhat.config.ts`: add `// eslint-disable-next-line no-console` for three intentional console.log calls in hardhat task/subtask handlers; add `// eslint-disable-next-line @typescript-eslint/no-explicit-any` for `getFileWithoutImports` param (hardhat internal type not importable)
- `test/v2/core/withdrawalQueueE2E.spec.ts`: suppress `no-explicit-any` for `vEth2` (mainnet fork contract — no Typechain types available without full hardhat typechain run)

## Verification
- [x] `npm run lint:ts` exits with 0 problems (was 5 warnings)
- [x] No new TypeScript errors introduced
- [x] Pre-existing tsc errors (missing typechain types in deploy/*.ts) unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSPkeTDHaXcDGJAQJyp6Mk)_