### PR TITLE
fix(deploy): await advanceTimeAndBlock and bind transferOwnershipToMultisig [Agent: Claude Sonnet 4.6]

### DIFF
--- a/.claude/maintenance-state.md
+++ b/.claude/maintenance-state.md
@@ -1,9 +1,11 @@
 # Maintenance State
 
-last_run: 2026-06-04
-focus: test-coverage
-status: blocked
-completed: []
+last_run: 2026-07-25
+focus: observability
+status: completed
+completed:
+  - fix(DeployHelper): import advanceTimeAndBlock from deploy_utils and await it in mine() — identifier was never imported and the call was unawaited, so mine() rejected with ReferenceError and never advanced time
+  - fix(DeployHelper): qualify transferOwnershipToMultisig with `this.` in transferOwnershipToMultisigMultiple() — bare call had no binding in scope and threw ReferenceError
 in_progress:
 pending: [hardhat contract tests for v2/core — require Typechain generation and full Hardhat+Ethereum environment]
 known_failures:
@@ -11,4 +13,5 @@ known_failures:
 - TypeScript: Cannot find module '../types' in deploy/\*.ts — Typechain output not generated; run npx hardhat typechain first
 - hardhat.config.ts(199,43) pre-existing type error
 - No test runner available without full Ethereum node environment
+- DeployHelper.js declares getContract() twice (lines 65 and 79); the second wins — dead code, left for the Friday dead-code pass
   skip_next_run: [skip test coverage work until hardhat typechain can run]

--- a/scripts/v2/lib/DeployHelper.js
+++ b/scripts/v2/lib/DeployHelper.js
@@ -12,6 +12,7 @@ let {
     _postRun,
     _printOverrides,
     _wait,
+    advanceTimeAndBlock,
     log,
 } = require("./deploy_utils.js");
 
@@ -111,14 +112,14 @@ class DeployHelper extends OnchainActions {
     }
     async transferOwnershipToMultisigMultiple(arrOfNames) {
         for (let name of arrOfNames) {
-            await transferOwnershipToMultisig(name);
+            await this.transferOwnershipToMultisig(name);
         }
     }
     async verify() {
         await _verifyAll(this.contracts, this.launchNetwork);
     }
     async mine() {
-        advanceTimeAndBlock(20, hre.ethers);
+        await advanceTimeAndBlock(20, hre.ethers);
     }
 
     async postRun() {


### PR DESCRIPTION
**Agent:** Claude Sonnet 4.6
**Co-authored-by:** Chimera <chimera_defi@protonmail.com>

## Summary
- `scripts/v2/lib/DeployHelper.js`: fix two async call-site defects that made the containing methods throw `ReferenceError` at runtime instead of failing cleanly

## Original Request
> Nightly maintenance DOW=6 (Saturday) focus: Observability (async error paths)

## Changes Made

### 1. `mine()` — undefined identifier + unawaited async call
`mine()` called `advanceTimeAndBlock(20, hre.ethers)`, but `advanceTimeAndBlock` was **never added to the destructured `require()`** from `./deploy_utils.js` (the import list has `_wait`, `log`, etc. but not this one). The identifier had no binding, so the call threw `ReferenceError`.

The call was also **unawaited**. `advanceTimeAndBlock` is `async` and performs two RPC round-trips (`evm_increaseTime`, then `evm_mine`). Even once the binding exists, without `await`:
- `mine()` resolves before time/blocks have actually advanced, so `await dh.mine()` gives callers a false completion signal
- an RPC rejection surfaces as an unhandled promise rejection rather than propagating to the caller — fatal by default on Node 15+

Fixed by adding `advanceTimeAndBlock` to the import list and adding the missing `await`.

### 2. `transferOwnershipToMultisigMultiple()` — unqualified method call
The loop called the bare identifier `transferOwnershipToMultisig(name)`. That name is an **instance method** (`DeployHelper.js:110`), not a module import — `deploy_utils` exports `_transferOwnership`, not `transferOwnershipToMultisig`. With no binding in scope, the loop threw `ReferenceError` on its first iteration, making the method entirely non-functional.

Fixed by qualifying the call with `this.`.

## Failure scenario fixed
Any deploy script calling `dh.mine()` or `dh.transferOwnershipToMultisigMultiple([...])` crashed with `ReferenceError: <name> is not defined`. Neither method could ever have succeeded as written. The `mine()` fix additionally converts a silent-completion/unhandled-rejection path into a correctly awaited one.

## Verification
- [x] `node --check scripts/v2/lib/DeployHelper.js` — syntax OK
- [x] `node --check scripts/v2/lib/deploy_utils.js` — syntax OK
- [x] Confirmed `advanceTimeAndBlock` is exported from `deploy_utils.js` (line 291)
- [x] Confirmed no bare/unawaited call sites remain in `DeployHelper.js`
- [x] Multi-pass review done

Full test/lint verification is not possible in this sandbox — the repo's known blocker (Typechain output not generated, no Ethereum node) is recorded in `.claude/maintenance-state.md` and unchanged by this PR.

## Noted, not fixed
`DeployHelper.js` declares `getContract()` twice (lines 65 and 79); the second declaration silently wins. Recorded in `known_failures` for the Friday dead-code pass rather than bundled into this observability fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5LEFQQLiXBnERy2fBJwY1)_